### PR TITLE
Static code analyzer setup

### DIFF
--- a/app/inc/config-moddwarf.h
+++ b/app/inc/config-moddwarf.h
@@ -6,7 +6,7 @@
 #include "device.h"
 
 //DEVELOPMENT DEFINES REMOVE LATER!!!!!
-//#define BOARD_REV_0_1
+#define BOARD_REV_0_1
 
 ////////////////////////////////////////////////////////////////
 ////// SETTINGS RELATED TO HARDWARE
@@ -91,7 +91,7 @@
 #define LED4_PINS           {0, 10, 0, 11, 2, 13}
 #define LED5_PINS           {1, 25, 1, 26, 1, 27}
 //mod button
-#define LED6_PINS           {4, 31, 1, 1, 5, 4}    
+#define LED6_PINS           {4, 31, 1, 1, 5, 4}
 
 //// GLCDs configurations
 // GLCD driver, valid options: KS0108, UC1701, ST7565P
@@ -335,7 +335,7 @@ enum {ENCODER0, ENCODER1, ENCODER2, FOOTSWITCH0, FOOTSWITCH1, FOOTSWITCH2, BUTTO
 
 #define MENU_LINE_CHARS     31
 
-//// Button functions leds colors, these reflect color ID's which are stored in eeprom. 
+//// Button functions leds colors, these reflect color ID's which are stored in eeprom.
 #define TOGGLED_COLOR             0
 #define TRIGGER_COLOR             1
 #define TRIGGER_PRESSED_COLOR     2
@@ -345,12 +345,12 @@ enum {ENCODER0, ENCODER1, ENCODER2, FOOTSWITCH0, FOOTSWITCH1, FOOTSWITCH2, BUTTO
 #define BYPASS_COLOR              6
 #define SNAPSHOT_COLOR            7
 #define SNAPSHOT_LOAD_COLOR       8
-#define LED_LIST_COLOR_1          9   
-#define LED_LIST_COLOR_2          10  
-#define LED_LIST_COLOR_3          11  
-#define LED_LIST_COLOR_4          12  
-#define LED_LIST_COLOR_5          13  
-#define LED_LIST_COLOR_6          14  
+#define LED_LIST_COLOR_1          9
+#define LED_LIST_COLOR_2          10
+#define LED_LIST_COLOR_3          11
+#define LED_LIST_COLOR_4          12
+#define LED_LIST_COLOR_5          13
+#define LED_LIST_COLOR_6          14
 #define LED_LIST_COLOR_7          15
 #define FS_PAGE_COLOR_1           16
 #define FS_PAGE_COLOR_2           17
@@ -362,7 +362,7 @@ enum {ENCODER0, ENCODER1, ENCODER2, FOOTSWITCH0, FOOTSWITCH1, FOOTSWITCH2, BUTTO
 #define FS_PAGE_COLOR_8           23
 #define FS_PB_MENU_COLOR          24
 #define FS_SS_MENU_COLOR          25
-#define ENCODER_PAGE_COLOR        26 
+#define ENCODER_PAGE_COLOR        26
 #define MAX_COLOR_ID              27
 
 #define DEFAULT_TOGGLED_COLOR             {100,0,0}
@@ -375,11 +375,11 @@ enum {ENCODER0, ENCODER1, ENCODER2, FOOTSWITCH0, FOOTSWITCH1, FOOTSWITCH2, BUTTO
 #define DEFAULT_SNAPSHOT_COLOR            {100,100,100}
 #define DEFAULT_SNAPSHOT_LOAD_COLOR       {0,100,100}
 #define DEFAULT_LED_LIST_COLOR_1          {100,100,100}
-#define DEFAULT_LED_LIST_COLOR_2          {100,0,0} 
-#define DEFAULT_LED_LIST_COLOR_3          {100,100,0} 
-#define DEFAULT_LED_LIST_COLOR_4          {0,100,100}  
-#define DEFAULT_LED_LIST_COLOR_5          {0,100,0}  
-#define DEFAULT_LED_LIST_COLOR_6          {100,0,100}  
+#define DEFAULT_LED_LIST_COLOR_2          {100,0,0}
+#define DEFAULT_LED_LIST_COLOR_3          {100,100,0}
+#define DEFAULT_LED_LIST_COLOR_4          {0,100,100}
+#define DEFAULT_LED_LIST_COLOR_5          {0,100,0}
+#define DEFAULT_LED_LIST_COLOR_6          {100,0,100}
 #define DEFAULT_LED_LIST_COLOR_7          {100,0,100}
 #define DEFAULT_FS_PAGE_COLOR_1           {100,0,0}
 #define DEFAULT_FS_PAGE_COLOR_2           {100,100,0}
@@ -448,7 +448,7 @@ enum {ENCODER0, ENCODER1, ENCODER2, FOOTSWITCH0, FOOTSWITCH1, FOOTSWITCH2, BUTTO
 #define DEFAULT_SL_INPUT                   0
 #define DEFAULT_SL_OUTPUT                  0
 
-//memory used for LED value's 
+//memory used for LED value's
 #define LED_COLOR_EEMPROM_PAGE             2
 #define LED_COLOR_ADRESS_START             0
 

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -145,7 +145,7 @@ static void actuators_cb(void *actuator)
     if (g_protocol_busy)
     {
         if (!naveg_dialog_status()) return;
-    }  
+    }
 
     static uint8_t i, info[ACTUATORS_QUEUE_SIZE][3];
 
@@ -206,7 +206,7 @@ static void webgui_procotol_task(void *pvParameters)
         // parses the message
         if (msg_size > 0)
         {
-            //if parsing messages block the actuator messages. 
+            //if parsing messages block the actuator messages.
             g_protocol_busy = true;
             system_lock_comm_serial(g_protocol_busy);
             msg_t msg;
@@ -237,7 +237,7 @@ static void system_procotol_task(void *pvParameters)
         // parses the message
         if (msg_size > 0)
         {
-            //if parsing messages block the actuator messages. 
+            //if parsing messages block the actuator messages.
             g_protocol_busy = true;
             system_lock_comm_serial(g_protocol_busy);
             msg_t msg;
@@ -314,7 +314,7 @@ static void actuators_task(void *pvParameters)
                     naveg_enc_enter(id);
                 }
                 if (BUTTON_HOLD(status))
-                {   
+                {
                     naveg_enc_hold(id);
                 }
                 if (ENCODER_TURNED_CW(status))
@@ -341,7 +341,7 @@ static void actuators_task(void *pvParameters)
                     {
                         naveg_foot_change(id, 1);
                     }
-                
+
                     if (BUTTON_RELEASED(status))
                     {
                         naveg_foot_change(id, 0);
@@ -354,7 +354,7 @@ static void actuators_task(void *pvParameters)
                     {
                         naveg_button_pressed(id-3);
                     }
-                
+
                     if (BUTTON_RELEASED(status))
                     {
                         naveg_button_released(id-3);
@@ -367,7 +367,7 @@ static void actuators_task(void *pvParameters)
                     {
                         naveg_shift_pressed();
                     }
-                
+
                     if (BUTTON_RELEASED(status))
                     {
                         naveg_shift_releaed();
@@ -506,3 +506,12 @@ void vApplicationStackOverflowHook(xTaskHandle *pxTask, signed portCHAR *pcTaskN
     ledz_on(hardware_leds(5), CYAN);
     while (1);
 }
+
+#ifdef CCC_ANALYZER
+// needed for the static analyzer to link properly
+void _start(void) {}
+void __bss_section_table_end(void) {}
+void __data_section_table(void) {}
+void __data_section_table_end(void) {}
+void _vStackTop(void) {}
+#endif

--- a/app/src/utils.c
+++ b/app/src/utils.c
@@ -358,22 +358,23 @@ char** str_array_duplicate(char** list, uint16_t count)
 {
     if (!list)
         return NULL;
-    
+
     char** ret = MALLOC((count+1)*sizeof(char*));
-    
+
     // out of memory
     if (!ret)
         return NULL;
-    
+
     for (size_t i=0; i<count; ++i)
         ret[i] = strdup(list[i]);
-    
+
     ret[count] = NULL;
     return ret;
 }
 
 void delay_us(volatile uint32_t time)
 {
+#ifndef CCC_ANALYZER
     register uint32_t _time asm ("r0");
     (void)(_time); // just to avoid warning
     _time = time;
@@ -392,10 +393,14 @@ void delay_us(volatile uint32_t time)
                 "b 1b\n\t"
             "4:\n\t"
     );
+#else
+    (void)(time);
+#endif
 }
 
 void delay_ms(volatile uint32_t time)
 {
+#ifndef CCC_ANALYZER
     register uint32_t _time asm ("r0");
     (void)(_time); // just to avoid warning
     _time = time;
@@ -414,6 +419,9 @@ void delay_ms(volatile uint32_t time)
                 "b 1b\n\t"
             "4:\n\t"
     );
+#else
+    (void)(time);
+#endif
 }
 
 float convert_to_ms(const char *unit_from, float value)

--- a/drivers/src/ledz.c
+++ b/drivers/src/ledz.c
@@ -116,7 +116,7 @@ typedef struct LED_STATE_T {
     uint8_t color;
     uint8_t state;
     int16_t time_on, time_off;
-    int8_t amount_of_blinks; 
+    int8_t amount_of_blinks;
 } led_state_t;
 
 /*
@@ -177,7 +177,7 @@ static inline void ledz_give(ledz_t *led)
 static inline ledz_color_t get_color_by_id(uint8_t color_pin_id)
 {
     switch(color_pin_id)
-    {   
+    {
         //red
         case 0:
             return LEDZ_RED;
@@ -243,7 +243,7 @@ ledz_t* ledz_create(ledz_type_t type, const ledz_color_t *colors, const int *pin
         return 0;
 
     ledz_t *next = 0;
-    
+
     int i;
     for (i = type - 1; i >= 0; i--)
     {
@@ -286,7 +286,7 @@ void ledz_off(ledz_t* led, ledz_color_t color)
     led->time_off = 0;
     led->brightness = 0;
     led->amount_of_blinks = -1;
-    
+
     ledz_set(led, color, 0);
 }
 
@@ -300,7 +300,7 @@ void ledz_set(ledz_t* led, ledz_color_t color, int value)
     // adjust value
     if (value >= 1)
         value = 1;
-    
+
     int i;
     for (i = 0; led; led = led->next, i++)
     {
@@ -312,7 +312,7 @@ void ledz_set(ledz_t* led, ledz_color_t color, int value)
             led->time_off = 0;
             led->brightness = 0;
             led->amount_of_blinks = -1;
-            
+
             // skip update if value match current state
             if (led->state == value)
                 continue;
@@ -334,7 +334,7 @@ void ledz_blink(ledz_t* led, ledz_color_t color, uint16_t time_on, uint16_t time
         led->blink = 0;
         return;
     }
-    
+
     int i;
     for (i = 0; led; led = led->next, i++)
     {
@@ -374,7 +374,7 @@ void ledz_brightness(ledz_t* led, ledz_color_t color, unsigned int value)
     for (i = 0; led; led = led->next, i++)
     {
         if (led->color & color)
-        {    
+        {
             // convert brightness value to duty cycle according cie 1931
             int duty_cycle = cie1931[value];
 
@@ -440,7 +440,7 @@ void ledz_tick(void)
         flag_1ms = 1;
     }
 
-    int i;  
+    int i;
     for (i = 0; i < LEDZ_MAX_INSTANCES; i++)
     {
         ledz_t *led = &g_leds[i];
@@ -488,7 +488,7 @@ void ledz_tick(void)
 
                 }
                 //stop blinking
-                else 
+                else
                 {
                     ledz_set_state(led, i, led->color, 1, 0, 0, 0);
                 }
@@ -564,7 +564,7 @@ void ledz_tick(void)
     }
 }
 
-void ledz_set_state(ledz_t* led, uint8_t led_id, uint8_t color, uint8_t state, uint16_t time_on, uint16_t time_off, int8_t amount_of_blinks)
+void ledz_set_state(ledz_t* led, uint8_t led_id, ledz_color_t color, uint8_t state, uint16_t time_on, uint16_t time_off, int8_t amount_of_blinks)
 {
     set_ledz_trigger_by_color_id(led, color, state, time_on, time_off, amount_of_blinks);
 

--- a/freertos/inc/portmacro.h
+++ b/freertos/inc/portmacro.h
@@ -75,6 +75,7 @@ typedef unsigned long UBaseType_t;
 #define portBYTE_ALIGNMENT			8
 /*-----------------------------------------------------------*/
 
+#ifndef CCC_ANALYZER
 /* Scheduler utilities. */
 #define portYIELD() 															\
 {																				\
@@ -86,6 +87,9 @@ typedef unsigned long UBaseType_t;
 	__asm volatile( "dsb" ::: "memory" );										\
 	__asm volatile( "isb" );													\
 }
+#else
+#define portYIELD() {}
+#endif
 
 #define portNVIC_INT_CTRL_REG		( * ( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT		( 1UL << 28UL )
@@ -129,10 +133,14 @@ not necessary for to use this port.  They are defined so the common demo files
 	/* Generic helper function. */
 	__attribute__( ( always_inline ) ) static inline uint8_t ucPortCountLeadingZeros( uint32_t ulBitmap )
 	{
+#ifndef CCC_ANALYZER
 	uint8_t ucReturn;
 
 		__asm volatile ( "clz %0, %1" : "=r" ( ucReturn ) : "r" ( ulBitmap ) : "memory" );
 		return ucReturn;
+#else
+		return ulBitmap;
+#endif
 	}
 
 	/* Check the configuration. */
@@ -192,6 +200,7 @@ BaseType_t xReturn;
 
 portFORCE_INLINE static void vPortRaiseBASEPRI( void )
 {
+#ifndef CCC_ANALYZER
 uint32_t ulNewBASEPRI;
 
 	__asm volatile
@@ -202,12 +211,14 @@ uint32_t ulNewBASEPRI;
 		"	dsb														\n" \
 		:"=r" (ulNewBASEPRI) : "i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) : "memory"
 	);
+#endif
 }
 
 /*-----------------------------------------------------------*/
 
 portFORCE_INLINE static uint32_t ulPortRaiseBASEPRI( void )
 {
+#ifndef CCC_ANALYZER
 uint32_t ulOriginalBASEPRI, ulNewBASEPRI;
 
 	__asm volatile
@@ -223,15 +234,22 @@ uint32_t ulOriginalBASEPRI, ulNewBASEPRI;
 	/* This return will not be reached but is necessary to prevent compiler
 	warnings. */
 	return ulOriginalBASEPRI;
+#else
+	return 0;
+#endif
 }
 /*-----------------------------------------------------------*/
 
 portFORCE_INLINE static void vPortSetBASEPRI( uint32_t ulNewMaskValue )
 {
+#ifndef CCC_ANALYZER
 	__asm volatile
 	(
 		"	msr basepri, %0	" :: "r" ( ulNewMaskValue ) : "memory"
 	);
+#else
+	(void)ulNewMaskValue;
+#endif
 }
 /*-----------------------------------------------------------*/
 

--- a/freertos/src/port.c
+++ b/freertos/src/port.c
@@ -216,6 +216,7 @@ volatile uint32_t ulDummy = 0UL;
 
 void vPortSVCHandler( void )
 {
+#ifndef CCC_ANALYZER
 	__asm volatile (
 					"	ldr	r3, pxCurrentTCBConst2		\n" /* Restore the context. */
 					"	ldr r1, [r3]					\n" /* Use pxCurrentTCBConst to get the pxCurrentTCB address. */
@@ -231,11 +232,13 @@ void vPortSVCHandler( void )
 					"	.align 4						\n"
 					"pxCurrentTCBConst2: .word pxCurrentTCB				\n"
 				);
+#endif
 }
 /*-----------------------------------------------------------*/
 
 static void prvPortStartFirstTask( void )
 {
+#ifndef CCC_ANALYZER
 	__asm volatile(
 					" ldr r0, =0xE000ED08 	\n" /* Use the NVIC offset register to locate the stack. */
 					" ldr r0, [r0] 			\n"
@@ -248,6 +251,7 @@ static void prvPortStartFirstTask( void )
 					" svc 0					\n" /* System call to start first task. */
 					" nop					\n"
 				);
+#endif
 }
 /*-----------------------------------------------------------*/
 
@@ -388,6 +392,7 @@ void vPortExitCritical( void )
 
 void xPortPendSVHandler( void )
 {
+#ifndef CCC_ANALYZER
 	/* This is a naked function. */
 
 	__asm volatile
@@ -420,6 +425,7 @@ void xPortPendSVHandler( void )
 	"pxCurrentTCBConst: .word pxCurrentTCB	\n"
 	::"i"(configMAX_SYSCALL_INTERRUPT_PRIORITY)
 	);
+#endif
 }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
This PR adds the needed bits to be able to run and build with a static code analyzer.

Run it like:
```
$ make clean
$ scan-build make moddwarf
scan-build: Using '/usr/lib/llvm-10/bin/clang' for static analysis
Building nxp-lpc/CMSISv2p00_LPC177x_8x/src/cr_startup_lpc177x_8x.c
Building nxp-lpc/CMSISv2p00_LPC177x_8x/src/core_cm3.c
Building nxp-lpc/CMSISv2p00_LPC177x_8x/src/system_LPC177x_8x.c
Building nxp-lpc/LPC177x_8xLib/src/lpc177x_8x_clkpwr.c
Building nxp-lpc/LPC177x_8xLib/src/lpc177x_8x_adc.c
Building nxp-lpc/LPC177x_8xLib/src/lpc177x_8x_gpio.c
Building nxp-lpc/LPC177x_8xLib/src/lpc177x_8x_pinsel.c
Building nxp-lpc/LPC177x_8xLib/src/lpc177x_8x_systick.c
nxp-lpc/LPC177x_8xLib/src/lpc177x_8x_systick.c:125:3: warning: Value stored to 'maxtime' is never read
                maxtime = (freq/1000)*time - 1;
                ^         ~~~~~~~~~~~~~~~~~~~~
1 warning generated.
Building nxp-lpc/LPC177x_8xLib/src/lpc177x_8x_timer.c
Building nxp-lpc/LPC177x_8xLib/src/lpc177x_8x_uart.c
nxp-lpc/LPC177x_8xLib/src/lpc177x_8x_uart.c:242:4: warning: Value stored to 'tmp' is never read
                        tmp = UARTx->RBR;
                        ^     ~~~~~~~~~~
nxp-lpc/LPC177x_8xLib/src/lpc177x_8x_uart.c:272:3: warning: Value stored to 'tmp' is never read
                tmp = UARTx->LSR;
                ^     ~~~~~~~~~~
nxp-lpc/LPC177x_8xLib/src/lpc177x_8x_uart.c:288:4: warning: Value stored to 'tmp' is never read
                        tmp = LPC_UART1->RBR;
                        ^     ~~~~~~~~~~~~~~
nxp-lpc/LPC177x_8xLib/src/lpc177x_8x_uart.c:318:3: warning: Value stored to 'tmp' is never read
                tmp = LPC_UART1->LSR;
                ^     ~~~~~~~~~~~~~~
nxp-lpc/LPC177x_8xLib/src/lpc177x_8x_uart.c:324:3: warning: Value stored to 'tmp' is never read
                tmp = LPC_UART1->MSR;
                ^     ~~~~~~~~~~~~~~
nxp-lpc/LPC177x_8xLib/src/lpc177x_8x_uart.c:340:4: warning: Value stored to 'tmp' is never read
                        tmp = LPC_UART4->RBR;
                        ^     ~~~~~~~~~~~~~~
nxp-lpc/LPC177x_8xLib/src/lpc177x_8x_uart.c:370:3: warning: Value stored to 'tmp' is never read
                tmp = LPC_UART4->LSR;
                ^     ~~~~~~~~~~~~~~
7 warnings generated.
Building nxp-lpc/LPC177x_8xLib/src/lpc177x_8x_ssp.c
nxp-lpc/LPC177x_8xLib/src/lpc177x_8x_ssp.c:339:3: warning: Value stored to 'tmp' is never read
                tmp = (uint32_t) SSP_ReceiveData(SSPx);
                ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
Building nxp-lpc/LPC177x_8xLib/src/lpc177x_8x_eeprom.c
/usr/share/clang/scan-build-10/bin/../libexec/ccc-analyzer -DCCC_ANALYZER -Wshadow -Wno-attributes -m32 -Wall -Wextra -Wpointer-arith -Wredundant-decls -Wsizeof-pointer-memaccess -Wa,-adhlns=./out/heap_5.lst -MMD -MP -MF ./out/dep/heap_5.o.d -I. -I./nxp-lpc -I./nxp-lpc/CMSISv2p00_LPC177x_8x/inc -I./nxp-lpc/LPC177x_8xLib/inc -I./freertos/inc -I./drivers/inc -I./app/inc -I./mod-controller-proto -DLPC177x_8x -O2 -o freertos/src/heap_5.o -c freertos/src/heap_5.c -Wno-unused-parameter -Wno-implicit-fallthrough
/usr/share/clang/scan-build-10/bin/../libexec/ccc-analyzer -DCCC_ANALYZER -Wshadow -Wno-attributes -m32 -Wall -Wextra -Wpointer-arith -Wredundant-decls -Wsizeof-pointer-memaccess -Wa,-adhlns=./out/queue.lst -MMD -MP -MF ./out/dep/queue.o.d -I. -I./nxp-lpc -I./nxp-lpc/CMSISv2p00_LPC177x_8x/inc -I./nxp-lpc/LPC177x_8xLib/inc -I./freertos/inc -I./drivers/inc -I./app/inc -I./mod-controller-proto -DLPC177x_8x -O2 -o freertos/src/queue.o -c freertos/src/queue.c -Wno-unused-parameter -Wno-implicit-fallthrough
/usr/share/clang/scan-build-10/bin/../libexec/ccc-analyzer -DCCC_ANALYZER -Wshadow -Wno-attributes -m32 -Wall -Wextra -Wpointer-arith -Wredundant-decls -Wsizeof-pointer-memaccess -Wa,-adhlns=./out/croutine.lst -MMD -MP -MF ./out/dep/croutine.o.d -I. -I./nxp-lpc -I./nxp-lpc/CMSISv2p00_LPC177x_8x/inc -I./nxp-lpc/LPC177x_8xLib/inc -I./freertos/inc -I./drivers/inc -I./app/inc -I./mod-controller-proto -DLPC177x_8x -O2 -o freertos/src/croutine.o -c freertos/src/croutine.c -Wno-unused-parameter -Wno-implicit-fallthrough
/usr/share/clang/scan-build-10/bin/../libexec/ccc-analyzer -DCCC_ANALYZER -Wshadow -Wno-attributes -m32 -Wall -Wextra -Wpointer-arith -Wredundant-decls -Wsizeof-pointer-memaccess -Wa,-adhlns=./out/list.lst -MMD -MP -MF ./out/dep/list.o.d -I. -I./nxp-lpc -I./nxp-lpc/CMSISv2p00_LPC177x_8x/inc -I./nxp-lpc/LPC177x_8xLib/inc -I./freertos/inc -I./drivers/inc -I./app/inc -I./mod-controller-proto -DLPC177x_8x -O2 -o freertos/src/list.o -c freertos/src/list.c -Wno-unused-parameter -Wno-implicit-fallthrough
/usr/share/clang/scan-build-10/bin/../libexec/ccc-analyzer -DCCC_ANALYZER -Wshadow -Wno-attributes -m32 -Wall -Wextra -Wpointer-arith -Wredundant-decls -Wsizeof-pointer-memaccess -Wa,-adhlns=./out/port.lst -MMD -MP -MF ./out/dep/port.o.d -I. -I./nxp-lpc -I./nxp-lpc/CMSISv2p00_LPC177x_8x/inc -I./nxp-lpc/LPC177x_8xLib/inc -I./freertos/inc -I./drivers/inc -I./app/inc -I./mod-controller-proto -DLPC177x_8x -O2 -o freertos/src/port.o -c freertos/src/port.c -Wno-unused-parameter -Wno-implicit-fallthrough
/usr/share/clang/scan-build-10/bin/../libexec/ccc-analyzer -DCCC_ANALYZER -Wshadow -Wno-attributes -m32 -Wall -Wextra -Wpointer-arith -Wredundant-decls -Wsizeof-pointer-memaccess -Wa,-adhlns=./out/stream_buffer.lst -MMD -MP -MF ./out/dep/stream_buffer.o.d -I. -I./nxp-lpc -I./nxp-lpc/CMSISv2p00_LPC177x_8x/inc -I./nxp-lpc/LPC177x_8xLib/inc -I./freertos/inc -I./drivers/inc -I./app/inc -I./mod-controller-proto -DLPC177x_8x -O2 -o freertos/src/stream_buffer.o -c freertos/src/stream_buffer.c -Wno-unused-parameter -Wno-implicit-fallthrough
/usr/share/clang/scan-build-10/bin/../libexec/ccc-analyzer -DCCC_ANALYZER -Wshadow -Wno-attributes -m32 -Wall -Wextra -Wpointer-arith -Wredundant-decls -Wsizeof-pointer-memaccess -Wa,-adhlns=./out/event_groups.lst -MMD -MP -MF ./out/dep/event_groups.o.d -I. -I./nxp-lpc -I./nxp-lpc/CMSISv2p00_LPC177x_8x/inc -I./nxp-lpc/LPC177x_8xLib/inc -I./freertos/inc -I./drivers/inc -I./app/inc -I./mod-controller-proto -DLPC177x_8x -O2 -o freertos/src/event_groups.o -c freertos/src/event_groups.c -Wno-unused-parameter -Wno-implicit-fallthrough
/usr/share/clang/scan-build-10/bin/../libexec/ccc-analyzer -DCCC_ANALYZER -Wshadow -Wno-attributes -m32 -Wall -Wextra -Wpointer-arith -Wredundant-decls -Wsizeof-pointer-memaccess -Wa,-adhlns=./out/tasks.lst -MMD -MP -MF ./out/dep/tasks.o.d -I. -I./nxp-lpc -I./nxp-lpc/CMSISv2p00_LPC177x_8x/inc -I./nxp-lpc/LPC177x_8xLib/inc -I./freertos/inc -I./drivers/inc -I./app/inc -I./mod-controller-proto -DLPC177x_8x -O2 -o freertos/src/tasks.o -c freertos/src/tasks.c -Wno-unused-parameter -Wno-implicit-fallthrough
/usr/share/clang/scan-build-10/bin/../libexec/ccc-analyzer -DCCC_ANALYZER -Wshadow -Wno-attributes -m32 -Wall -Wextra -Wpointer-arith -Wredundant-decls -Wsizeof-pointer-memaccess -Wa,-adhlns=./out/timers.lst -MMD -MP -MF ./out/dep/timers.o.d -I. -I./nxp-lpc -I./nxp-lpc/CMSISv2p00_LPC177x_8x/inc -I./nxp-lpc/LPC177x_8xLib/inc -I./freertos/inc -I./drivers/inc -I./app/inc -I./mod-controller-proto -DLPC177x_8x -O2 -o freertos/src/timers.o -c freertos/src/timers.c -Wno-unused-parameter -Wno-implicit-fallthrough
Building drivers/src/uc1701.c
Building drivers/src/actuator.c
drivers/src/actuator.c: In function 'actuator_set_event':
drivers/src/actuator.c:278:48: warning: declaration of 'event' shadows a global declaration [-Wshadow]
  278 | void actuator_set_event(void *actuator, void (*event)(void *actuator))
      |                                         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
drivers/src/actuator.c:98:13: note: shadowed declaration is here
   98 | static void event(void *actuator, uint8_t flags)
      |             ^~~~~
drivers/src/actuator.c: In function 'actuators_clock':
drivers/src/actuator.c:458:43: warning: declaration of 'other_button' shadows a previous local [-Wshadow]
  458 |                                 button_t *other_button;
      |                                           ^~~~~~~~~~~~
drivers/src/actuator.c:351:27: note: shadowed declaration is here
  351 |                 button_t *other_button = NULL;
      |                           ^~~~~~~~~~~~
drivers/src/actuator.c:491:43: warning: declaration of 'other_button' shadows a previous local [-Wshadow]
  491 |                                 button_t *other_button;
      |                                           ^~~~~~~~~~~~
drivers/src/actuator.c:351:27: note: shadowed declaration is here
  351 |                 button_t *other_button = NULL;
      |                           ^~~~~~~~~~~~
drivers/src/actuator.c:387:51: warning: Access to field 'control' results in a dereference of a null pointer (loaded from variable 'other_button')
                                if (button_on == (other_button->control & BUTTON_ON_FLAG))
                                                  ^~~~~~~~~~~~~~~~~~~~~
1 warning generated.
Building drivers/src/ks0108.c
Building drivers/src/ledz.c
Building drivers/src/st7565p.c
Building app/src/protocol.c
app/src/protocol.c:247:5: warning: Value stored to 'i' is never read
    i += int_to_str(value, &buffer[i], sizeof(buffer) - i, 0);
    ^    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
Building app/src/hardware.c
Building app/src/mode_control.c
Building app/src/system.c
Building app/src/screen.c
app/src/screen.c: In function 'screen_menu_page':
app/src/screen.c:1190:17: warning: unused variable 'char_cnt_name' [-Wunused-variable]
 1190 |         uint8_t char_cnt_name = 0;
      |                 ^~~~~~~~~~~~~
app/src/screen.c:1189:14: warning: unused variable 'str_bfr' [-Wunused-variable]
 1189 |         char str_bfr[6];
      |              ^~~~~~~
app/src/screen.c:980:30: warning: Dereference of null pointer
                list.hover = last_item->data.hover;
                             ^~~~~~~~~~~~~~~~~~~~~
1 warning generated.
Building app/src/mode_tools.c
app/src/mode_tools.c: In function 'TM_menu_item_changed_cb':
app/src/mode_tools.c:572:38: warning: unused parameter 'item_ID' [-Wunused-parameter]
  572 | void TM_menu_item_changed_cb(uint8_t item_ID, uint16_t value)
      |                              ~~~~~~~~^~~~~~~
app/src/mode_tools.c:572:56: warning: unused parameter 'value' [-Wunused-parameter]
  572 | void TM_menu_item_changed_cb(uint8_t item_ID, uint16_t value)
      |                                               ~~~~~~~~~^~~~~
Building app/src/cli.c
Building app/src/sys_comm.c
Building app/src/ui_comm.c
Building app/src/node.c
Building app/src/mode_navigation.c
Building app/src/images.c
Building app/src/naveg.c
Building app/src/main.c
Building app/src/glcd_widget.c
app/src/glcd_widget.c: In function 'widget_bar_encoder':
app/src/glcd_widget.c:819:19: warning: declaration of 'value' shadows a previous local [-Wshadow]
  819 |         textbox_t value;
      |                   ^~~~~
app/src/glcd_widget.c:799:15: note: shadowed declaration is here
  799 |     textbox_t value;
      |               ^~~~~
Building app/src/serial.c
Building app/src/data.c
Building app/src/mode-builder.c
Building app/src/utils.c
Linking objects: generating ELF
scan-build: 12 bugs found.
scan-build: Run 'scan-view /tmp/scan-build-2020-12-10-181921-35463-1' to examine bug reports
```

In Ubuntu 20.04 I have scan-build-10 and scan-view-10 tools, based on clang 10.
